### PR TITLE
Rework ADR-002 Validation Before Save chapter to use ValidationRule

### DIFF
--- a/service/doc/010-architecture/022-adr002.md
+++ b/service/doc/010-architecture/022-adr002.md
@@ -341,33 +341,6 @@ public class PriceRowValidPriceTypeRule implements ValidationRule<PriceRowEntity
 }
 ```
 
-### 7.2 Service Integration
-
-The service receives all registered validation rules via constructor injection and uses an `EntityValidator` to execute them.
-
-```java
-@Service
-public class PriceRowServiceImpl implements PriceRowService {
-
-    private final EntityValidator<PriceRowEntity> entityValidator;
-
-    public PriceRowServiceImpl(
-            PriceRowEntityRepository priceRowEntityRepository,
-            List<ValidationRule<PriceRowEntity>> validationRules,
-            ...) {
-        this.priceRowEntityRepository = priceRowEntityRepository;
-        this.entityValidator = new EntityValidator<>(validationRules);
-        ...
-    }
-
-    @Override
-    public PriceRowEntity save(PriceRowEntity entity) throws EntityValidationException {
-        // Validation is triggered before save (e.g., inside performGenericSave)
-        validateEntity(entity);
-        return priceRowEntityRepository.save(entity);
-    }
-}
-```
 
 ---
 

--- a/service/doc/010-architecture/022-adr002.md
+++ b/service/doc/010-architecture/022-adr002.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Accepted
+Accepted (with open questions, impelementation details)
 
 ## Context
 
@@ -111,7 +111,7 @@ Static Java enums remain acceptable for truly fixed business concepts that are n
 
 If you choose the **Value Object + Dynamic Registry** approach from the ADR, the entity would no longer store a Java enum. Instead, it stores a value object (or a string in the database) that is validated against a Spring-managed registry.
 
-## 1. Replace Enum with Value Object
+## Option 3 - Step 1: Replace Enum with Value Object
 
 ### Before
 
@@ -128,9 +128,7 @@ private PriceType priceType;
 private PriceType priceType;
 ```
 
----
-
-## 2. Value Object
+## Option 3 - Step 2: Value Object
 
 ```java
 package io.commercestacksolutions.priceproviderservice.domain.pricetype;
@@ -158,9 +156,7 @@ new PriceType("purchase_price");
 new PriceType("custom_partner_price");
 ```
 
----
-
-## 3. JPA Converter
+## Option 3 - Step 3: JPA Converter
 
 JPA cannot persist a custom value object automatically.
 
@@ -195,9 +191,8 @@ material_cost
 partner_special_price
 ```
 
----
 
-## 4. Registry Interface
+## Option 3 - Step 4: PriceTypeDefinition Interface and type-safe Price Types (to be discussed /)
 
 ```java
 package io.commercestacksolutions.priceproviderservice.domain.pricetype;
@@ -209,10 +204,6 @@ public interface PriceTypeDefinition {
     String getDisplayName();
 }
 ```
-
----
-
-## 5. Default Price Types
 
 ```java
 @Component
@@ -246,9 +237,9 @@ public class PurchasePriceType implements PriceTypeDefinition {
 }
 ```
 
----
 
-## 6. Registry
+
+## Option 3 - Step 5. Registry
 
 Spring automatically discovers all implementations.
 
@@ -293,11 +284,9 @@ public class PriceTypeRegistry {
 
 ---
 
-## 7. Validation Before Save
+## Option 3 - Step 6: Validation Rule (Validation Before Save)
 
 Validation is performed using the `ValidationRule` pattern. Each save operation triggers the registered validation rules.
-
-### 7.1 Validation Rule
 
 The validation logic is encapsulated in a dedicated rule that uses the registry to verify the price type.
 
@@ -342,9 +331,7 @@ public class PriceRowValidPriceTypeRule implements ValidationRule<PriceRowEntity
 ```
 
 
----
-
-## 8. External Partner Extension
+## Option 3 - Step 7: External Partner Extension
 
 A partner module can contribute a new type without modifying existing code:
 
@@ -371,3 +358,7 @@ No change required in:
 * `PriceTypeRegistry`
 
 The new type is discovered automatically by Spring.
+
+## Remaining Open Questions
+
+* How to work with PriceTypeDefinitions on REST-API layer? It's nice to work with type-safe definitions but extra back-and-forth-conversion is required. Sample implentation required. Maybe working with simple PriceTypes and String keys is enough and more flexible.

--- a/service/doc/010-architecture/022-adr002.md
+++ b/service/doc/010-architecture/022-adr002.md
@@ -192,7 +192,7 @@ partner_special_price
 ```
 
 
-## Option 3 - Step 4: PriceTypeDefinition Interface and type-safe Price Types (to be discussed /)
+## Option 3 - Step 4: PriceTypeDefinition Interface and type-safe PriceTypeDefinition (to be discussed)
 
 ```java
 package io.commercestacksolutions.priceproviderservice.domain.pricetype;

--- a/service/doc/010-architecture/022-adr002.md
+++ b/service/doc/010-architecture/022-adr002.md
@@ -295,23 +295,76 @@ public class PriceTypeRegistry {
 
 ## 7. Validation Before Save
 
-Example service:
+Validation is performed using the `ValidationRule` pattern. Each save operation triggers the registered validation rules.
+
+### 7.1 Validation Rule
+
+The validation logic is encapsulated in a dedicated rule that uses the registry to verify the price type.
 
 ```java
-@Service
-public class PriceRowService {
+package io.commercestacksolutions.priceproviderservice.service.pricerow.validation;
+
+import io.commercestacksolutions.commons.service.entity.validation.ValidationRule;
+import io.commercestacksolutions.commons.web.rest.Message;
+import io.commercestacksolutions.priceproviderservice.dataaccess.pricerow.entity.PriceRowEntity;
+import io.commercestacksolutions.priceproviderservice.domain.pricetype.PriceTypeRegistry;
+import org.springframework.stereotype.Component;
+
+import java.util.Collections;
+import java.util.List;
+
+@Component
+public class PriceRowValidPriceTypeRule implements ValidationRule<PriceRowEntity> {
 
     private final PriceTypeRegistry registry;
 
-    public PriceRowService(PriceTypeRegistry registry) {
+    public PriceRowValidPriceTypeRule(PriceTypeRegistry registry) {
         this.registry = registry;
     }
 
-    public PriceRowEntity save(PriceRowEntity entity) {
+    @Override
+    public List<Message> validate(PriceRowEntity entity) {
+        if (entity == null || entity.getPriceType() == null) {
+            return Collections.emptyList();
+        }
 
-        registry.validate(entity.getPriceType());
+        if (!registry.exists(entity.getPriceType().code())) {
+            return Collections.singletonList(new Message(
+                Message.MessageType.ERROR,
+                "Unknown price type: " + entity.getPriceType().code(),
+                List.of("priceType")
+            ));
+        }
 
-        return repository.save(entity);
+        return Collections.emptyList();
+    }
+}
+```
+
+### 7.2 Service Integration
+
+The service receives all registered validation rules via constructor injection and uses an `EntityValidator` to execute them.
+
+```java
+@Service
+public class PriceRowServiceImpl implements PriceRowService {
+
+    private final EntityValidator<PriceRowEntity> entityValidator;
+
+    public PriceRowServiceImpl(
+            PriceRowEntityRepository priceRowEntityRepository,
+            List<ValidationRule<PriceRowEntity>> validationRules,
+            ...) {
+        this.priceRowEntityRepository = priceRowEntityRepository;
+        this.entityValidator = new EntityValidator<>(validationRules);
+        ...
+    }
+
+    @Override
+    public PriceRowEntity save(PriceRowEntity entity) throws EntityValidationException {
+        // Validation is triggered before save (e.g., inside performGenericSave)
+        validateEntity(entity);
+        return priceRowEntityRepository.save(entity);
     }
 }
 ```


### PR DESCRIPTION
Reworked the "Validation Before Save" chapter in ADR-002 (service/doc/010-architecture/022-adr002.md) to use the `ValidationRule` pattern as requested.

The documentation now includes:
- An implementation example of `PriceRowValidPriceTypeRule` using `PriceTypeRegistry`.
- An updated `PriceRowServiceImpl` snippet demonstrating how validation rules are injected and executed via `EntityValidator` during the save operation.

This change aligns the architectural documentation with the project's actual validation framework.

---
*PR created automatically by Jules for task [57392885136397183](https://jules.google.com/task/57392885136397183) started by @commerce-stack-solutions*