### PR TITLE
Fix service path references in build scripts

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     defaults:
       run:
-        working-directory: service
+        working-directory: services/applications/priceprovider
 
     steps:
       - name: Check out repository
@@ -36,7 +36,13 @@ jobs:
           cache: gradle
 
       - name: Make Gradle wrapper executable
-        run: chmod +x ./gradlew
+        run: |
+          chmod +x ./gradlew
+          chmod +x ../../platform/commons/gradlew
+
+      - name: Run commons tests
+        working-directory: services/platform/commons
+        run: ./gradlew test
 
       - name: Run service tests
         run: ./gradlew test
@@ -50,7 +56,7 @@ jobs:
           import xml.etree.ElementTree as ET
 
           tests = failures = errors = skipped = 0
-          files = glob.glob('build/test-results/test/*.xml')
+          files = glob.glob('build/test-results/test/*.xml') + glob.glob('../../platform/commons/build/test-results/test/*.xml')
           for path in files:
               root = ET.parse(path).getroot()
               tests += int(root.attrib.get('tests', 0))
@@ -71,7 +77,9 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: service-test-report
-          path: service/build/reports/tests/test
+          path: |
+            services/applications/priceprovider/build/reports/tests/test
+            services/platform/commons/build/reports/tests/test
           if-no-files-found: warn
 
   app-angular-tests:

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 .idea/
 app/pricemanager-app/package-lock.json
-service/logs/
+services/applications/priceprovider/logs/
 **/node_modules/
 **/dist/
 **/build/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 # AGENTS.md
 This repository contains two sub-projects:
 
-- subfolder `service/` – the priceprovider service is a Java / Spring Boot backend using Gradle, see [AGENTS.md](service/AGENTS.md) for project specific architecture, conventions, and development guidelines
+- subfolder `services/applications/priceprovider/` – the priceprovider service is a Java / Spring Boot backend using Gradle, see [AGENTS.md](services/applications/priceprovider/AGENTS.md) for project specific architecture, conventions, and development guidelines
 - subfolder `app/` – the pricemanager app is an Angular frontend using Node.js and Bootstrap, see [AGENTS.md](app/AGENTS.md) for project specific architecture, conventions, and development guidelines
 
 Each project follows modern best practices and is structured for scalability, maintainability, and developer productivity.

--- a/build-and-run-devenv.bat
+++ b/build-and-run-devenv.bat
@@ -78,7 +78,7 @@ echo   [1/2] Building Docker image for Price Provider Service...
 echo         Image: price-provider-service:%VERSION%
 echo.
 
-pushd "%SCRIPT_DIR%\service"
+pushd "%SCRIPT_DIR%\services\applications\priceprovider"
 call dockerimage-create.bat %VERSION%
 if %errorlevel% neq 0 (
     echo ERROR: Failed to build Price Provider Service image.
@@ -188,7 +188,7 @@ echo       rental-green-land  / rental123 (Org: Green Land^)
 echo.
 echo   Documentation:
 echo   Project README         -^>  %SCRIPT_DIR%\README.md
-echo   Service README         -^>  %SCRIPT_DIR%\service\README.md
+echo   Service README         -^>  %SCRIPT_DIR%\services\applications\priceprovider\README.md
 echo   App README             -^>  %SCRIPT_DIR%\app\README.md
 echo   Shop Frontend README   -^>  %SCRIPT_DIR%\examples\shopfrontend\README.md
 echo   Rental Frontend README -^>  %SCRIPT_DIR%\examples\rentalfrontend\README.md

--- a/build-and-run-devenv.sh
+++ b/build-and-run-devenv.sh
@@ -72,7 +72,7 @@ echo ""
 echo "  [1/2] Building Docker image for Price Provider Service..."
 echo "        Image: price-provider-service:${VERSION}"
 echo ""
-(cd "${SCRIPT_DIR}/service" && bash dockerimage-create.sh "${VERSION}")
+(cd "${SCRIPT_DIR}/services/applications/priceprovider" && bash dockerimage-create.sh "${VERSION}")
 echo ""
 
 # ---------------------------------------------------------------------------
@@ -157,11 +157,11 @@ echo "      rental-green-land  / rental123 (Org: Green Land)"
 echo ""
 echo "  Documentation:"
 echo "  Project README         ->  $(link "file://${SCRIPT_DIR}/README.md")"
-echo "  Service README         ->  $(link "file://${SCRIPT_DIR}/service/README.md")"
+echo "  Service README         ->  $(link "file://${SCRIPT_DIR}/services/applications/priceprovider/README.md")"
 echo "  App README             ->  $(link "file://${SCRIPT_DIR}/app/README.md")"
 echo "  Shop Frontend README   ->  $(link "file://${SCRIPT_DIR}/examples/shopfrontend/README.md")"
 echo "  Rental Frontend README ->  $(link "file://${SCRIPT_DIR}/examples/rentalfrontend/README.md")"
-  In-Store Kiosk README  ->  $(link "file://${SCRIPT_DIR}/examples/instorekiosk/README.md")"
+echo "  In-Store Kiosk README  ->  $(link "file://${SCRIPT_DIR}/examples/instorekiosk/README.md")"
 echo ""
 echo "  To stream logs:  docker compose logs -f"
 echo "  To stop:         docker compose down"

--- a/deployment/azure-container-apps/06-create-service-image.bat
+++ b/deployment/azure-container-apps/06-create-service-image.bat
@@ -23,10 +23,10 @@ set "VERSION=%~1"
 REM ============================================================
 REM  Resolve the service source directory
 REM  This script lives in deployment/azure-container-apps/
-REM  The service Dockerfile is in service/ (two levels up)
+REM  The service Dockerfile is in services/ (two levels up)
 REM ============================================================
 set "SCRIPT_DIR=%~dp0"
-set "SERVICE_DIR=%SCRIPT_DIR%..\..\service"
+set "SERVICE_DIR=%SCRIPT_DIR%..\..\services"
 
 REM ============================================================
 REM  Log in to ACR

--- a/deployment/azure-container-apps/06-create-service-image.sh
+++ b/deployment/azure-container-apps/06-create-service-image.sh
@@ -24,9 +24,9 @@ VERSION="$1"
 # ============================================================
 #  Resolve the service source directory
 #  This script lives in deployment/azure-container-apps/
-#  The service Dockerfile is in service/ (two levels up)
+#  The service Dockerfile is in services/ (two levels up)
 # ============================================================
-SERVICE_DIR="${SCRIPT_DIR}/../../service"
+SERVICE_DIR="${SCRIPT_DIR}/../../services"
 
 # ============================================================
 #  Log in to ACR

--- a/deployment/azure-container-apps/README.md
+++ b/deployment/azure-container-apps/README.md
@@ -104,7 +104,7 @@ Scripts 06 and 07 build a Docker image locally (requires Docker Desktop) and pus
 
 ### Option A – Build locally then push (scripts 06/07)
 
-Both image scripts resolve the source directories automatically (`../../service/` and `../../app/` relative to this folder), so they can be run from any working directory.
+Both image scripts resolve the source directories automatically (`../../services/` and `../../app/` relative to this folder), so they can be run from any working directory.
 
 #### Build and push the backend image
 

--- a/services/applications/priceprovider/dockerimage-create.bat
+++ b/services/applications/priceprovider/dockerimage-create.bat
@@ -1,4 +1,7 @@
 @echo off
+REM Always run from this script directory so relative paths are stable
+cd /d "%~dp0"
+
 REM Use provided version or default to 0.0.0-SNAPSHOT
 if [%1]==[] (
     set VERSION=0.0.0-SNAPSHOT
@@ -11,6 +14,6 @@ set IMAGE_NAME="price-provider-service"
 echo Building Docker image %IMAGE_NAME%:%VERSION%...
 
 REM Build the Docker image
-docker build -t %IMAGE_NAME%:%VERSION% .
+docker build -t %IMAGE_NAME%:%VERSION% -f ..\..\Dockerfile ..\..
 
 echo Docker image %IMAGE_NAME%:%VERSION% built successfully.

--- a/services/applications/priceprovider/dockerimage-create.sh
+++ b/services/applications/priceprovider/dockerimage-create.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+# Always execute from this script directory so relative paths are stable
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "${SCRIPT_DIR}"
+
 # Use provided version or default to 0.0.0-SNAPSHOT
 VERSION=${1:-0.0.0-SNAPSHOT}
 IMAGE_NAME="price-provider-service"
@@ -7,6 +11,6 @@ IMAGE_NAME="price-provider-service"
 echo "Building Docker image ${IMAGE_NAME}:${VERSION}..."
 
 # Build the Docker image
-docker build -t ${IMAGE_NAME}:${VERSION} .
+docker build -t ${IMAGE_NAME}:${VERSION} -f ../../Dockerfile ../..
 
 echo "Docker image ${IMAGE_NAME}:${VERSION} built successfully."


### PR DESCRIPTION
Fixed all build and Docker image script issues caused by the restructuring of the backend service to the 'services/applications/priceprovider' path. All references to 'service/' are updated to the correct relative paths.

---
*PR created automatically by Jules for task [3226609798050887973](https://jules.google.com/task/3226609798050887973) started by @commerce-stack-solutions*